### PR TITLE
Use Commit Search API if email is not publicly listed

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,29 +18,33 @@ module.exports = (email, token) => {
 		const data = result.body;
 
 		if (data.total_count === 0) {
-			return ghGot('search/commits', {
-				token,
-				query: {
-					q: `author-email:${email}`,
-					sort: 'author-date',
-					// eslint-disable-next-line camelcase
-					per_page: 1
-				},
-				headers: {
-					accept: 'application/vnd.github.cloak-preview',
-					'user-agent': 'https://github.com/sindresorhus/github-username'
-				}
-			}).then(result => {
-				const data = result.body;
-
-				if (data.total_count === 0) {
-					throw new Error(`Couldn't find username for \`${email}\``);
-				}
-
-				return data.items[0].author.login;
-			});
+			return searchCommits(email, token);
 		}
 
 		return data.items[0].login;
 	});
 };
+
+function searchCommits(email, token) {
+	return ghGot('search/commits', {
+		token,
+		query: {
+			q: `author-email:${email}`,
+			sort: 'author-date',
+			// eslint-disable-next-line camelcase
+			per_page: 1
+		},
+		headers: {
+			accept: 'application/vnd.github.cloak-preview',
+			'user-agent': 'https://github.com/sindresorhus/github-username'
+		}
+	}).then(result => {
+		const data = result.body;
+
+		if (data.total_count === 0) {
+			throw new Error(`Couldn't find username for \`${email}\``);
+		}
+
+		return data.items[0].author.login;
+	});
+}

--- a/index.js
+++ b/index.js
@@ -37,12 +37,7 @@ module.exports = (email, token) => {
 					throw new Error(`Couldn't find username for \`${email}\``);
 				}
 
-				return ghGot(`user/${data.items[0].author_id}`, {
-					token
-				});
-			}).then(result => {
-				const data = result.body;
-				return data.login;
+				return data.items[0].author.login;
 			});
 		}
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,32 @@ module.exports = (email, token) => {
 		const data = result.body;
 
 		if (data.total_count === 0) {
-			throw new Error(`Couldn't find username for \`${email}\``);
+			return ghGot('search/commits', {
+				token,
+				query: {
+					q: `author-email:${email}`,
+					sort: 'author-date',
+					// eslint-disable-next-line camelcase
+					per_page: 1
+				},
+				headers: {
+					accept: 'application/vnd.github.cloak-preview',
+					'user-agent': 'https://github.com/sindresorhus/github-username'
+				}
+			}).then(result => {
+				const data = result.body;
+
+				if (data.total_count === 0) {
+					throw new Error(`Couldn't find username for \`${email}\``);
+				}
+
+				return ghGot(`user/${data.items[0].author_id}`, {
+					token
+				});
+			}).then(result => {
+				const data = result.body;
+				return data.login;
+			});
 		}
 
 		return data.items[0].login;

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,6 @@
 
 > Get a GitHub username from an email address
 
-*Only works for users that have their email publicly listed on their profile.*
-
 
 ## Install
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,10 @@ test('gets GitHub username from email', async t => {
 	t.is(await m('sindresorhus@gmail.com'), 'sindresorhus');
 });
 
+test('gets GitHub username from email using Commit Search API', async t => {
+	t.is(await m('markdotto@gmail.com'), 'mdo');
+});
+
 test('rejects when GitHub has no user for the email', async t => {
 	await t.throws(m('nogithubaccount@example.com'));
 });


### PR DESCRIPTION
Using the new [Commit Search API](https://developer.github.com/v3/search/#search-commits), we can get the GitHub username via the latest commit even if the user doesn’t have their email publicly listed on their profile.

It might be good to hold off on this because the API is currently only available for preview and may therefore “change without advance notice”.