### PR TITLE
TypeScript - Properly mark `token` as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,6 @@ import githubUsername = require('github-username');
 })();
 ```
 */
-declare function githubUsername(email: string, token: string): Promise<string>;
+declare function githubUsername(email: string, token?: string): Promise<string>;
 
 export = githubUsername;


### PR DESCRIPTION
You marked the token as a required argument despite it not being so in all other documentation. This causes a conflict for TS users.