### PR TITLE
Upgrade package to Node v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
+          - 18
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,15 @@
-export interface Options {
+export type Options = {
 	/**
 	GitHub [personal access token](https://github.com/settings/tokens/new).
 	*/
 	readonly token?: string;
-}
+};
 
 /**
 Get the GitHub username from an email address if the email can be found in any commits on GitHub.
 
 @param email - The email address for the user of whom you want the username.
+@param options - You can pass token in the options f.e {token: ''}
 @returns The username for the `email` or `undefined` if it cannot be found.
 
 @example
@@ -18,5 +19,5 @@ import githubUsername from 'github-username';
 console.log(await githubUsername('sindresorhus@gmail.com'));
 //=> 'sindresorhus'
 ```
-*/
+ */
 export default function githubUsername(email: string, options?: Options): Promise<string | undefined>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "github-username",
-	"version": "7.0.0",
+	"version": "8.0.0",
 	"description": "Get a GitHub username from an email address",
 	"license": "MIT",
 	"repository": "sindresorhus/github-username",
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": ">=18.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -32,11 +32,11 @@
 		"git"
 	],
 	"dependencies": {
-		"@octokit/rest": "^18.12.0"
+		"@octokit/rest": "^20.0.1"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.18.0",
-		"xo": "^0.45.0"
+		"ava": "^5.3.1",
+		"tsd": "^0.28.1",
+		"xo": "^0.55.0"
 	}
 }


### PR DESCRIPTION
The time has come for the Node v18 and a lot of packages are getting upgraded as it introduces a breaking change - fetch is now bundled and it generally conflicts with `node-fetch`

This PR upgrades all the npm packages and bumps minimum engine supported