### PR TITLE
Update to Octokit v21, remove support for Node 16, add support for Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
-          - 16
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"default": "./index.js"
 	},
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -35,11 +35,11 @@
 		"git"
 	],
 	"dependencies": {
-		"@octokit/rest": "^19.0.13"
+		"@octokit/rest": "^21.1.1"
 	},
 	"devDependencies": {
-		"ava": "^5.3.1",
-		"tsd": "^0.28.1",
-		"xo": "^0.55.0"
+		"ava": "^6.2.0",
+		"tsd": "^0.31.2",
+		"xo": "^0.60.0"
 	}
 }


### PR DESCRIPTION
The [latest version](https://github.com/octokit/rest.js/releases) of `@octokit/rest` is 21.1.1 - it fixes some security vulnerabilities related to regular expressions that were present in dependent packages. Packages that depend on this one would like to update in order to patch these vulnerabilities.

This change:
* Updates `@octokit/rest` to the latest to fix the ReDos security vulnerabilities
* Updates the dev dependencies to the latest versions
* Updates the node version matrix to remove support for Node 16, because `@octokit/rest` v20 removed Node 16 support in https://github.com/octokit/rest.js/pull/305
* Adds Node 22 to the support matrix, since it's the latest LTS release
* Updates to the latest version of GitHub actions